### PR TITLE
fix: Catch exception during TV shutdown

### DIFF
--- a/bscpylgtv/webos_client.py
+++ b/bscpylgtv/webos_client.py
@@ -310,6 +310,7 @@ class WebOsClient:
             asyncio.TimeoutError,
             asyncio.CancelledError,
             websockets.exceptions.ConnectionClosedError,
+            websockets.exceptions.ConnectionClosedOK,
         ):
             pass
 


### PR DESCRIPTION
The following exception happens when the TV is turned off and the `Quick Start+` feature is disabled:
```python
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/aiopylgtv/webos_client.py", line 340, in ping_handler
    ping_waiter = await ws.ping()
  File "/usr/local/lib/python3.9/site-packages/websockets/legacy/protocol.py", line 657, in ping
    await self.ensure_open()
  File "/usr/local/lib/python3.9/site-packages/websockets/legacy/protocol.py", line 735, in ensure_open
    raise self.connection_closed_exc()
websockets.exceptions.ConnectionClosedOK: code = 1001 (going away), reason = server shutting down
```

This PR adds this exception to the silent exceptions since it is a normal behavior of the TV and should not raise an exception.