### PR TITLE
Fix client reconnect

### DIFF
--- a/bscpylgtv/webos_client.py
+++ b/bscpylgtv/webos_client.py
@@ -266,7 +266,7 @@ class WebOsClient:
 
             self.connection = None
             self.input_connection = None
-
+            self.handler_tasks = set()
             self.doStateUpdate = False
 
             self.storage = None


### PR DESCRIPTION
**Clean previous `handler_tasks` to allow calling connect again after client is disconnected**

The following example code is used to show the problem:
```python
import asyncio
from contextlib import suppress

from websockets.exceptions import ConnectionClosed, ConnectionClosedOK

from bscpylgtv import WebOsClient
from bscpylgtv.exceptions import PyLGTVCmdException

CLIENT_IP = "192.168.1.20"

WEBOSTV_EXCEPTIONS = (
    OSError,
    ConnectionClosed,
    ConnectionClosedOK,
    ConnectionRefusedError,
    PyLGTVCmdException,
    asyncio.TimeoutError,
    asyncio.CancelledError,
)


async def runloop():
    client = await WebOsClient.create(CLIENT_IP)

    while True:
        if not client.is_connected():
            with suppress(WEBOSTV_EXCEPTIONS):
                await client.connect()

        print(f"Connected: {client.is_connected()}, Power state: {client.is_on}")

        await asyncio.sleep(1)


asyncio.run(runloop())
```

When the client is disconnected `self.handler_tasks` is not cleared so that on next call to `connect` it contains tasks that are in `done` state and will cause the new `connect_handler` task will finish before new tasks are done.
