### PR TITLE
Handle `blackLevel` change in WebOS 25

### DIFF
--- a/bscpylgtv/webos_client.py
+++ b/bscpylgtv/webos_client.py
@@ -2359,6 +2359,18 @@ class WebOsClient:
 
         return await self.luna_request(ep.LUNA_SET_WHITE_BALANCE, params)
 
+    async def normalize_settings(self, response: dict) -> dict:
+        """Parse system settings to deal with SDK inconsistencies over time"""
+
+        normalized = response
+        if 'settings' in response and 'blackLevel' in response['settings']:
+            # blackLevel changed from dict to str in WebOS 25
+            if isinstance(response['settings']['blackLevel'], dict):
+                normalized['settings']['blackLevel'] = response['settings']['blackLevel'].get('unknown', 'unknown')
+            else:
+                normalized['settings']['blackLevel'] = response['settings']['blackLevel']
+        return normalized
+
     async def get_system_settings(self, category="option", keys=["audioGuidance"], jsonOutput=False):
         """Get system settings.
 
@@ -2442,7 +2454,8 @@ class WebOsClient:
 
         payload = {"category": category, "keys": keys}
         res = await self.request(ep.GET_SYSTEM_SETTINGS, payload=payload)
-        return self.__output_result(res, jsonOutput)
+        normalized_res = await self.normalize_settings(res)
+        return self.__output_result(normalized_res, jsonOutput)
 
     async def get_picture_settings(
         self, keys=["contrast", "backlight", "brightness", "color"], jsonOutput=False


### PR DESCRIPTION
Previously, `blackLevel` was a dict: `{'secam': 'auto', 'ntsc': 'auto', 'pal60': 'auto', 'ntsc443': 'auto', 'pal': 'auto', 'unknown': 'auto', 'paln': 'auto', 'palm': 'auto'}`.

Now it's a string: `auto`.

This change works in both cases.  In the former, we assume the correct value is in the key called `unknown`.

I tested this on a CX running 04.63.25, G4 running 23.23.05, and G4 running 33.21.85.  I'm not sure if it will break something for someone using one of those ancient formats.