### PR TITLE
feat: replace print with logging

### DIFF
--- a/bscpylgtv/__init__.py
+++ b/bscpylgtv/__init__.py
@@ -1,6 +1,10 @@
+import logging
+
 from ._version import __version__, __version_info__
 from .exceptions import PyLGTVCmdException, PyLGTVPairException
 from .webos_client import StorageSqliteDict, WebOsClient
+
+logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 try:
     from .lut_tools import (

--- a/bscpylgtv/storage_proto.py
+++ b/bscpylgtv/storage_proto.py
@@ -8,5 +8,5 @@ class StorageProto(Protocol):
     async def get_key(self, key):
         """Get value of key from storage."""
 
-    async def list_keys(self):
-        """Display all key value pairs from storage."""
+    async def list_keys(self) -> dict:
+        """Return all key value pairs from storage."""

--- a/bscpylgtv/storage_sqlitedict.py
+++ b/bscpylgtv/storage_sqlitedict.py
@@ -45,6 +45,5 @@ class StorageSqliteDict:
         return self.db.get(key)
 
     async def list_keys(self):
-        """Display all key value pairs from storage."""
-        for key, value in self.db.iteritems():
-            print(key, value)
+        """Return all key value pairs from storage."""
+        return dict(self.db.iteritems())

--- a/bscpylgtv/utils.py
+++ b/bscpylgtv/utils.py
@@ -1,6 +1,7 @@
 import argparse
 import asyncio
 import json
+import logging
 
 from ._version import __version__
 from bscpylgtv import WebOsClient
@@ -26,7 +27,7 @@ async def runloop(args):
             current.append(arg)
     if current:
         commands.append(current)
-    
+
     client = await WebOsClient.create(
         ip=args.host,
         timeout_connect=args.timeout_connect,
@@ -71,6 +72,9 @@ def convert_arg(arg):
 
 
 def bscpylgtvcommand():
+    logging.basicConfig(level=logging.WARNING, format="%(message)s")
+    logging.getLogger("bscpylgtv").setLevel(logging.DEBUG)
+
     parser = argparse.ArgumentParser(description="Send command to LG WebOs TV.")
     parser.add_argument(
         "-v", "--version",

--- a/bscpylgtv/utils.py
+++ b/bscpylgtv/utils.py
@@ -9,7 +9,9 @@ from bscpylgtv import WebOsClient
 async def list_keys(path_key_file):
     client = await WebOsClient.create(None, key_file_path=path_key_file)
     storage = await client.get_storage()
-    await storage.list_keys()
+    keys = await storage.list_keys()
+    for key, value in keys.items():
+        print(key, value)
 
 async def runloop(args):
     # parse multiple commands with parameters separated by ","

--- a/bscpylgtv/webos_client.py
+++ b/bscpylgtv/webos_client.py
@@ -2,6 +2,7 @@ import asyncio
 import base64
 import functools
 import json
+import logging
 import os
 import ssl
 from datetime import timedelta
@@ -46,6 +47,8 @@ if np:
         unity_lut_3d,
         convert_1dlut_to_cal_format,
     )
+
+logger = logging.getLogger(__name__)
 
 SOUND_OUTPUTS_TO_DELAY_CONSECUTIVE_VOLUME_STEPS = {"external_arc"}
 
@@ -134,7 +137,7 @@ class WebOsClient:
                 with open(manifest_file_path, 'r', encoding="utf-8") as f:
                     self.manifest = json.load(f)
             except Exception as e:
-                print(f"Error loading manifest file, using default instead: {e}")
+                logger.warning("Error loading manifest file, using default instead: %s", e)
 
     @classmethod
     async def create(cls, *args, **kwargs):
@@ -208,7 +211,7 @@ class WebOsClient:
                 except asyncio.TimeoutError as ex:
                     if attempt < self.connect_retry_attempts - 1:
                         await asyncio.sleep(self.connect_retry_interval_ms / 1000)
-                        print(f"Connection attempt: {attempt + 2}")
+                        logger.info("Connection attempt: %d", attempt + 2)
                         continue
                     else:
                         raise
@@ -528,9 +531,6 @@ class WebOsClient:
     def clear_state_update_callbacks(self):
         self.state_update_callbacks = []
 
-    async def print(self, message):
-        print(message)
-
     async def sleep(self, seconds):
         await asyncio.sleep(seconds)
 
@@ -735,7 +735,7 @@ class WebOsClient:
             if self.input_connection is None:
                 sockres = await self.request(ep.INPUT_SOCKET)
                 inputsockpath = sockres.get("socketPath")
-                
+
                 # Try connecting up to 5 times to mitigate transient timeouts
                 for attempt in range(self.connect_retry_attempts):
                     try:
@@ -752,7 +752,7 @@ class WebOsClient:
                     except asyncio.TimeoutError as ex:
                         if attempt < self.connect_retry_attempts - 1:
                             await asyncio.sleep(self.connect_retry_interval_ms / 1000)
-                            print(f"Connection attempt: {attempt + 2}")
+                            logger.info("Connection attempt: %d", attempt + 2)
                             continue
                         else:
                             raise
@@ -1912,7 +1912,7 @@ class WebOsClient:
             with open(os.path.join(full_path, DV_CONFIG_FILENAME), "w", newline='\r\n') as f:
                 f.write(config)
 
-            print(f"Generated DoVi config file: {DV_CONFIG_FILENAME}")
+            logger.info("Generated DoVi config file: %s", DV_CONFIG_FILENAME)
             return True
 
         async def convert_1dlut_to_cal(self, in_file, out_file):
@@ -1933,7 +1933,7 @@ class WebOsClient:
             with open(out_file, "w", newline='\r\n') as f:
                 f.write(content)
 
-            print(f"Converted cal file: {out_file}")
+            logger.info("Converted cal file: %s", out_file)
             return True
 
         async def convert_cal_to_1dlut(self, in_file, out_file):
@@ -1960,7 +1960,7 @@ class WebOsClient:
                 ),
             )
 
-            print(f"Converted 1DLUT file: {out_file}")
+            logger.info("Converted 1DLUT file: %s", out_file)
             return result
 
         async def set_itpg_patch_window(

--- a/bscpylgtv/webos_client.py
+++ b/bscpylgtv/webos_client.py
@@ -211,7 +211,7 @@ class WebOsClient:
                 except asyncio.TimeoutError as ex:
                     if attempt < self.connect_retry_attempts - 1:
                         await asyncio.sleep(self.connect_retry_interval_ms / 1000)
-                        logger.info("Connection attempt: %d", attempt + 2)
+                        logger.debug("Connection attempt: %d", attempt + 2)
                         continue
                     else:
                         raise
@@ -752,7 +752,7 @@ class WebOsClient:
                     except asyncio.TimeoutError as ex:
                         if attempt < self.connect_retry_attempts - 1:
                             await asyncio.sleep(self.connect_retry_interval_ms / 1000)
-                            logger.info("Connection attempt: %d", attempt + 2)
+                            logger.debug("Connection attempt: %d", attempt + 2)
                             continue
                         else:
                             raise


### PR DESCRIPTION
I call `WebOsClient` from another app, and since 475c42c5423a707627aac69b059bda3c8087fcd0, my logs are cluttered with lines like `Connection attempt: 2`.  I prefer to hide that in debug level.

I also changed `list_keys` storage proto to return a dict, so it can be printed by whomever calls it. I don't actually use that function, it just seemed like a good improvement while I'm here.