### PR TITLE
fix(calibration): pass shape positionally to reshape

### DIFF
--- a/bscpylgtv/webos_client.py
+++ b/bscpylgtv/webos_client.py
@@ -1458,7 +1458,7 @@ class WebOsClient:
             npType = getattr(np, type[0])
             data_bytes = base64.b64decode(encodedData.encode())
             deserialized_bytes = np.frombuffer(data_bytes, dtype=npType)
-            data = np.reshape(deserialized_bytes, newshape=shape)
+            data = np.reshape(deserialized_bytes, shape)
             self.validateCalibrationData(data, shape, npType, None, dataCount)
 
             if filename:


### PR DESCRIPTION
This PR removes the `newshape` named parameter passed to `numpy.reshape`, which was deprecated in NumPy 2.1.0 and removed in [2.4.0](https://numpy.org/devdocs/release/2.4.0-notes.html#removed-newshape-parameter-from-numpy-reshape). The new shape is instead passed positionally, as recommended.

Version 1.17.0 [seems to be compatible](https://github.com/numpy/numpy/blob/d9b1e32cb8ef90d6b4a47853241db2a28146a57d/numpy/core/fromnumeric.py#L203), so updating the dependency version in `setup.py` should not be needed.